### PR TITLE
Add propType.any

### DIFF
--- a/examples/src/components/core/props/DataProps.stories.ts
+++ b/examples/src/components/core/props/DataProps.stories.ts
@@ -130,3 +130,17 @@ export const DataObject: Story = () => ({
     <pre data-ref="info"></pre>
   </div>`,
 });
+
+export const DataAny: Story = () => ({
+  component: createPropsComponent({
+    str: propType.any,
+    strDefault: propType.any.defaultValue('default-value'),
+    int: propType.any,
+    intDefault: propType.any.defaultValue(42),
+    bool: propType.any,
+    boolDefault: propType.any.defaultValue(true),
+  }),
+  template: () => html` <div data-component="props" data-str="value" data-int="1" data-bool="true">
+    <pre data-ref="info"></pre>
+  </div>`,
+});

--- a/src/lib/props/propDefinitions.ts
+++ b/src/lib/props/propDefinitions.ts
@@ -158,4 +158,5 @@ export const propType = {
   object: generateType(Object, {}),
   array: generateType(Array, {}),
   func: createFunc(Function, {}),
+  any: generateType({} as any, {}),
 };

--- a/src/lib/props/property-sources/convertSourceValue.ts
+++ b/src/lib/props/property-sources/convertSourceValue.ts
@@ -8,6 +8,7 @@ export function convertSourceValue(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): any {
   switch (propInfo.type) {
+    default:
     case String: {
       return value;
     }


### PR DESCRIPTION
When extracting these from HTML, they will just be passed as-is, no conversion is done.

All other propType modifiers work as usual, only the typing is different.