### PR TITLE
Improve bindMap and other bindings after bindTemplate updates

### DIFF
--- a/examples/src/components/core/bindings/RefLifecycle.stories.ts
+++ b/examples/src/components/core/bindings/RefLifecycle.stories.ts
@@ -1,0 +1,173 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Story } from '@muban/storybook/dist/client/preview/types-6-0';
+import { html } from '@muban/template';
+import {
+  bind,
+  bindMap,
+  defineComponent,
+  onMounted,
+  onUnmounted,
+  refCollection,
+  refElement,
+} from '../../../../../src';
+
+export default {
+  title: 'core/bindings/ref-lifecycle',
+};
+
+export const Element: Story = () => ({
+  component: defineComponent({
+    name: 'ref-lifecycle',
+    refs: {
+      container: 'container',
+      btnAdd: 'btnAdd',
+      btnRemove: 'btnRemove',
+      btnDestroy: 'btnDestroy',
+      testButton: refElement('testButton', { isRequired: false }),
+    },
+    setup({ refs }) {
+      onMounted(() => {
+        console.log('[mounted]');
+      });
+      onUnmounted(() => {
+        console.log('[unmounted]');
+      });
+      return [
+        bind(refs.btnAdd, {
+          click() {
+            if (refs.container.element) {
+              refs.container.element.innerHTML = html`<button data-ref="testButton">test</button>`;
+            }
+          },
+        }),
+        bind(refs.btnRemove, {
+          click() {
+            if (refs.container.element) {
+              refs.container.element.innerHTML = '';
+            }
+          },
+        }),
+        bind(refs.btnDestroy, {
+          click() {
+            if (refs.self.element?.parentElement) {
+              refs.self.element.parentElement.innerHTML = '';
+            }
+          },
+        }),
+        bind(refs.testButton, { click: () => console.log('test') }),
+      ];
+    },
+  }),
+  template: () => html` <div data-component="ref-lifecycle">
+    <button data-ref="btnAdd">add</button>
+    <button data-ref="btnRemove">remove</button>
+    <button data-ref="btnDestroy">destroy</button>
+    <div data-ref="container"></div>
+  </div>`,
+});
+
+export const Collection: Story = () => ({
+  component: defineComponent({
+    name: 'ref-lifecycle',
+    refs: {
+      container: 'container',
+      btnAdd: 'btnAdd',
+      btnRemove: 'btnRemove',
+      btnDestroy: 'btnDestroy',
+      testButton: refCollection('testButton'),
+    },
+    setup({ refs }) {
+      onMounted(() => {
+        console.log('[mounted]');
+      });
+      onUnmounted(() => {
+        console.log('[unmounted]');
+      });
+      return [
+        bind(refs.btnAdd, {
+          click() {
+            console.log('refs.container.element', refs.container.element);
+            if (refs.container.element) {
+              console.log('append');
+              refs.container.element.innerHTML += html`<button data-ref="testButton">test</button>`;
+            }
+          },
+        }),
+        bind(refs.btnRemove, {
+          click() {
+            if (refs.container.element) {
+              refs.container.element.innerHTML = '';
+            }
+          },
+        }),
+        bind(refs.btnDestroy, {
+          click() {
+            if (refs.self.element?.parentElement) {
+              refs.self.element.parentElement.innerHTML = '';
+            }
+          },
+        }),
+        bind(refs.testButton, { click: () => console.log('test') }),
+      ];
+    },
+  }),
+  template: () => html` <div data-component="ref-lifecycle">
+    <button data-ref="btnAdd">add</button>
+    <button data-ref="btnRemove">remove</button>
+    <button data-ref="btnDestroy">destroy</button>
+    <div data-ref="container"></div>
+  </div>`,
+});
+
+export const Map: Story = () => ({
+  component: defineComponent({
+    name: 'ref-lifecycle',
+    refs: {
+      container: 'container',
+      btnAdd: 'btnAdd',
+      btnRemove: 'btnRemove',
+      btnDestroy: 'btnDestroy',
+      testButton: refCollection('testButton'),
+    },
+    setup({ refs }) {
+      onMounted(() => {
+        console.log('[mounted]');
+      });
+      onUnmounted(() => {
+        console.log('[unmounted]');
+      });
+      return [
+        bind(refs.btnAdd, {
+          click() {
+            console.log('refs.container.element', refs.container.element);
+            if (refs.container.element) {
+              console.log('append');
+              refs.container.element.innerHTML += html`<button data-ref="testButton">test</button>`;
+            }
+          },
+        }),
+        bind(refs.btnRemove, {
+          click() {
+            if (refs.container.element) {
+              refs.container.element.innerHTML = '';
+            }
+          },
+        }),
+        bind(refs.btnDestroy, {
+          click() {
+            if (refs.self.element?.parentElement) {
+              refs.self.element.parentElement.innerHTML = '';
+            }
+          },
+        }),
+        ...bindMap(refs.testButton, (ref, index) => ({ click: () => console.log('test', index) })),
+      ];
+    },
+  }),
+  template: () => html` <div data-component="ref-lifecycle">
+    <button data-ref="btnAdd">add</button>
+    <button data-ref="btnRemove">remove</button>
+    <button data-ref="btnDestroy">destroy</button>
+    <div data-ref="container"></div>
+  </div>`,
+});

--- a/src/lib/Component.ts
+++ b/src/lib/Component.ts
@@ -241,6 +241,7 @@ function createObservers(instance: InternalComponentInstance) {
       instance.unmount();
     }
   });
+  // TODO: only add this once
   documentObserver.observe(document, { attributes: false, childList: true, subtree: true });
 }
 

--- a/src/lib/bindings/applyBindings.ts
+++ b/src/lib/bindings/applyBindings.ts
@@ -67,7 +67,6 @@ export const applyBindings = (
             );
             onInvalidate(() => {
               // TODO debug
-              // console.log('onInvalidate element');
               bindings.forEach((binding) => binding && binding());
             });
           },
@@ -75,7 +74,7 @@ export const applyBindings = (
         );
       } else if (binding.type === 'collection') {
         return watch(
-          () => unref(binding.ref),
+          () => unref(binding.ref).map((ref) => unref(ref)),
           (elements, oldValue, onInvalidate) => {
             const bindingHelpers = createBindingsHelpers(binding);
             const bindings = typedObjectEntries(binding.props).flatMap(
@@ -98,7 +97,6 @@ export const applyBindings = (
               },
             );
             onInvalidate(() => {
-              console.log('onInvalidate collection');
               bindings.forEach((binding) => binding && binding());
             });
           },
@@ -125,7 +123,7 @@ export const applyBindings = (
       } else if (binding.type === 'componentCollection') {
         typedObjectEntries(binding.props).forEach(([propName, bindingValue]) => {
           watchEffect(() => {
-            const reff = unref(binding.ref);
+            const reff = unref(binding.ref).map((r) => unref(r));
             reff?.forEach((ref) => {
               watchEffect(() => {
                 if (['css', 'style', 'attr'].includes(propName)) {
@@ -165,6 +163,8 @@ export const applyBindings = (
           },
           { immediate: !!renderImmediate },
         );
+      } else if (binding.type === 'bindMap') {
+        return binding.dispose;
       }
     });
   }

--- a/src/lib/bindings/bindingDefinitions.ts
+++ b/src/lib/bindings/bindingDefinitions.ts
@@ -39,7 +39,7 @@ export function bind<T extends Pick<AnyRef, 'getBindingDefinition'>>(
 
 export type BindMapBinding = {
   type: 'bindMap';
-  getElements(): Array<RefElementType>;
+  getElements(): ReadonlyArray<RefElementType>;
   // eslint-disable-next-line @typescript-eslint/ban-types
   props: {};
   dispose: () => void;
@@ -105,7 +105,7 @@ export function bindMap(
         const removeBindingList = applyBindings(bindings, instance) || [];
 
         onInvalidate(() => {
-          removeBindingList.forEach((binding) => binding && binding());
+          removeBindingList.forEach((binding) => binding?.());
         });
       },
       { immediate: true },
@@ -129,7 +129,7 @@ export function bindMap(
 export type TemplateBinding<T extends RefElementType> = {
   type: 'template';
   props: TemplateProps<T>;
-  getElements(): Array<RefElementType>;
+  getElements(): ReadonlyArray<RefElementType>;
 };
 export function BindTemplate<T extends RefElementType>(
   props: TemplateProps<T>,
@@ -189,13 +189,13 @@ export function bindElement<T extends RefElementType, P extends BindProps>(
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export type CollectionBinding<T extends RefElementType, P extends BindProps> = {
-  ref: Ref<Array<Ref<T>>>;
+  ref: Ref<ReadonlyArray<Ref<T>>>;
   type: 'collection';
   props: P;
-  getElements(): Array<T>;
+  getElements(): ReadonlyArray<T>;
 };
 export function bindCollection<T extends RefElementType, P extends BindProps>(
-  ref: Ref<Array<Ref<T>>>,
+  ref: Ref<ReadonlyArray<Ref<T>>>,
   props: P,
 ): CollectionBinding<T, P> {
   return {
@@ -215,7 +215,7 @@ export type ComponentBinding<T extends SimpleComponentApi> = {
   ref: Ref<T | undefined>;
   type: 'component';
   props: ComponentParams<T>;
-  getElements(): Array<RefElementType>;
+  getElements(): ReadonlyArray<RefElementType>;
 };
 export function BindComponent<T extends SimpleComponentApi>(
   ref: Ref<T | undefined>,
@@ -233,13 +233,13 @@ export function BindComponent<T extends SimpleComponentApi>(
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export type ComponentCollectionBinding<T extends SimpleComponentApi> = {
-  ref: Ref<Array<Ref<T>>>;
+  ref: Ref<ReadonlyArray<Ref<T>>>;
   type: 'componentCollection';
   props: ComponentParams<T>;
-  getElements(): Array<RefElementType>;
+  getElements(): ReadonlyArray<RefElementType>;
 };
 export function bindComponentCollection<T extends SimpleComponentApi>(
-  ref: Ref<Array<Ref<T>>>,
+  ref: Ref<ReadonlyArray<Ref<T>>>,
   props: ComponentParams<T>,
 ): ComponentCollectionBinding<T> {
   return {

--- a/src/lib/bindings/bindings.types.ts
+++ b/src/lib/bindings/bindings.types.ts
@@ -2,6 +2,7 @@
 import type { Ref } from '@vue/reactivity';
 import type { RefElementType } from '../refs/refDefinitions.types';
 import type { ElementRef } from '../refs/refDefinitions.types';
+import type { BindMapBinding } from './bindingDefinitions';
 import type {
   CollectionBinding,
   ComponentBinding,
@@ -28,7 +29,8 @@ export type Binding =
   | CollectionBinding<RefElementType, BindProps>
   | ComponentBinding<SimpleComponentApi>
   | ComponentCollectionBinding<SimpleComponentApi>
-  | TemplateBinding<RefElementType>;
+  | TemplateBinding<RefElementType>
+  | BindMapBinding;
 
 export type BindingValue<T> = Ref<T>;
 export type BindingMap<T> = Ref<Record<string, T>> | Record<string, Ref<T>>;

--- a/src/lib/refs/refDefinitions.ts
+++ b/src/lib/refs/refDefinitions.ts
@@ -164,7 +164,7 @@ export function refCollection<T extends RefElementType = RefElementType>(
       );
     },
     createRef(instance) {
-      const elementsRef = ref([]) as Ref<Array<Ref<T>>>;
+      const elementsRef = ref([]) as Ref<ReadonlyArray<Ref<T>>>;
       const getElements = () => {
         const elements = this.queryRef(instance.element as HTMLElement);
         if (elements.length < minimumItemsRequired) {
@@ -334,7 +334,7 @@ export function refComponents<T extends ComponentFactory<any>>(
       );
     },
     createRef(instance) {
-      const instancesRef = ref([]) as Ref<Array<Ref<ReturnType<T>>>>;
+      const instancesRef = ref([]) as Ref<ReadonlyArray<Ref<ReturnType<T>>>>;
 
       const getComponents = () => {
         const elements = this.queryRef(instance.element as HTMLElement);


### PR DESCRIPTION
Previously there were some memory leaks regarding bindMap when
the HTML was updated with bindTemplate. New bindings were created
to make everything work, but old bindings were not removed.

The fix here is done in two ways:

1) The `getRefs` for collections how returns an array or refs that
are managed by the collection itself, so when the collection changes,
these refs can be set to `undefined`, so any bindings to this ref
will be cleaned up.

2) Additionally, bindMap now cleans up its own bindings, and registers
it watcher to the Component instance, so both gets cleaned up.