### PR TITLE
Make the props object readonly

### DIFF
--- a/docs/api/component.md
+++ b/docs/api/component.md
@@ -144,6 +144,11 @@ You can find more info at the [Refs API](./refs.md)
 
 ### setup
 
+::: warning Readonly 
+The `props` object passed to the `setup` function is **readonly**, so it cannot be used to
+communicate back to the parent component or as initial state.
+:::
+
 ### lifecycle
 
 [See hooks](./hooks.md)

--- a/docs/guide/props.md
+++ b/docs/guide/props.md
@@ -14,7 +14,7 @@ application.
 ### Initial State
 
 So, how is this "initial state" stored inside the HTML, and how can we extract that to make it 
-usable in our component? We can divide this up into 3 different catgories:
+usable in our component? We can divide this up into 3 different categories:
 
 1) **Explicit state** – stored in `data-attributes` or `<script type="application/json">`, that 
    serves no function on the page for the user, but allows us to extract that state into our 
@@ -100,6 +100,11 @@ component in their setup function, since the setup function of the parent compon
 to execute. Use `watch` or `watchEffect` if you need to know when they become available.
 
 > TODO; link to full component lifecycle
+
+### Read Only
+
+The `props` object passed to the `setup` function is **readonly**, so it cannot be used to
+communicate back to the parent component or as initial state.
 
 ## Prop Definition
 

--- a/src/lib/Component.ts
+++ b/src/lib/Component.ts
@@ -31,7 +31,7 @@ import type {
   DefineComponentOptions,
   InternalComponentInstance,
 } from './Component.types';
-import { reactive, toRaw, watchEffect } from '@vue/runtime-core';
+import { reactive, toRaw, watchEffect, readonly } from '@vue/runtime-core';
 import type { ComponentRefItem } from './refs/refDefinitions.types';
 import { recursiveUnref } from './utils/utils';
 
@@ -338,7 +338,7 @@ function setupComponent(instance: InternalComponentInstance) {
   currentInstance = instance;
   // console.log('[setup]', instance.options.name);
   const bindings = instance.options.setup?.({
-    props: instance.reactiveProps as any,
+    props: readonly(instance.reactiveProps) as any,
     refs: instance.refs,
     element: instance.element as HTMLElement,
   });

--- a/src/lib/Component.types.ts
+++ b/src/lib/Component.types.ts
@@ -90,7 +90,7 @@ export type DefineComponentOptions<
   props?: P;
   refs?: R;
   setup?: (context: {
-    props: TypedProps<P>;
+    props: Readonly<TypedProps<P>>;
     refs: TypedRefs<R>;
     element: HTMLElement;
   }) => undefined | null | Array<Binding>;


### PR DESCRIPTION
The props object passed to the setup function inside a component contains information from the outside, either from the HTML (initially), or from the parent component.

The direction of information is meant to be one-way, so writing back to props should not be used. It already never communicated back to the HTML or parent component, so it could only be used for "internal state".

While this internal state sounds useful, it can also be confusing. Making this readonly makes it clear that props should only be used for one thing. If you try to write to it, it will log a warning in the console.