### PR TITLE
Check current HTML value before setting innerHTML

### DIFF
--- a/src/lib/bindings/dom/htmlBinding.ts
+++ b/src/lib/bindings/dom/htmlBinding.ts
@@ -1,5 +1,20 @@
 import { unref, watchEffect } from '@vue/runtime-core';
+// import { debounce } from 'lodash-es';
 import type { BindingValue } from '../bindings.types';
+
+// TODO: this might be _slightly_ more performant, but could have downsides
+//  like race conditions or queue-mismanagement
+// const queue = [] as Array<[HTMLElement, string]>;
+// const processQueue = debounce(() => {
+//   console.log('process', queue.length);
+//   // optimized code
+//   for (let i = 0; i < queue.length; ++i) {
+//     if (queue[i][0].innerHTML !== queue[i][1]) {
+//       queue[i][0].innerHTML = queue[i][1];
+//     }
+//   }
+//   queue.length = 0;
+// }, 10);
 
 /**
  * We don't safety-check anything, it's your responsibility to make sure the HTML is safe.
@@ -11,5 +26,18 @@ import type { BindingValue } from '../bindings.types';
  * @param value
  */
 export function htmlBinding(target: HTMLElement, valueAccessor: BindingValue<string>) {
-  return watchEffect(() => (target.innerHTML = unref(valueAccessor)));
+  return watchEffect(() => {
+    const newValue = unref(valueAccessor);
+    // only update HTML when it has changed
+    // - reading it is fairly cheap
+    // - writing when nothing has changed causes MutationObserver to trigger, which can be heavy
+    if (target.innerHTML !== newValue) {
+      target.innerHTML = newValue;
+    }
+  });
+  // TODO; see above in file
+  // return watchEffect(() => {
+  //   queue.push([target, unref(valueAccessor)]);
+  //   processQueue();
+  // });
 }


### PR DESCRIPTION
Setting innerHTML (even if the value is the same) triggers
MutationObserver checks to see if either new components should be
initialized, or if existing components should be unmounted.

Since reading the current DOM is much cheaper compared to the writing +
side-effects, this should improve things.

The commented out code was a simple "batching" implementation that seems
to benefit slightly in synthetic benchmarks, but since its current
implementation is not robust enough, it's currently still disabled.