### PR TITLE
Improve performance with global MutationObserver

### DIFF
--- a/examples/src/components/atom/cf-a2-icon/CfA2Icon.ts
+++ b/examples/src/components/atom/cf-a2-icon/CfA2Icon.ts
@@ -1,4 +1,4 @@
-import { bind, defineComponent, propType } from '../../../../../src';
+import { bind, defineComponent, propType, supportLazy } from '../../../../../src';
 
 import './cf-a2-icon.scss';
 import { isIcon, svgContext } from './CfA2Icon.config';
@@ -17,3 +17,5 @@ export const CfA2Icon = defineComponent({
     ];
   },
 });
+
+export const lazy = supportLazy(CfA2Icon);

--- a/examples/src/components/use-cases/performance/Performance.stories.ts
+++ b/examples/src/components/use-cases/performance/Performance.stories.ts
@@ -1,0 +1,63 @@
+import { html } from '@muban/template';
+import type { Story } from '@muban/storybook/dist/client/preview/types-6-0';
+import { bind, computed, defineComponent, lazy, propType } from '../../../../../src';
+import { cfA1Heading } from '../../atom/cf-a1-heading/CfA1Heading';
+import { cfA2IconTemplate } from '../../atom/cf-a2-icon/CfA2Icon.template';
+
+export default {
+  title: 'use-cases/performance',
+};
+
+export const Icons: Story = () => ({
+  appComponents: [
+    lazy('cf-a2-icon', () => import(/* webpackExports: "lazy" */ '../../atom/cf-a2-icon/CfA2Icon')),
+  ],
+  component: defineComponent({
+    name: 'global-refresh',
+    setup({}) {
+      console.log('foo');
+      return [];
+    },
+  }),
+  template: () => html` <div data-component="global-refresh">
+    <div data-component="child">
+      ${cfA1Heading({ title: 'The quick brown fox jumped over the lazy dog', type: 'h1' })}
+      ${cfA2IconTemplate({ name: 'loader' })}
+      ${Array.from({ length: 1000 }, () => cfA2IconTemplate({ name: 'arrow-up' }))}
+    </div>
+  </div>`,
+});
+
+const TextTest = defineComponent({
+  name: 'text-test',
+  props: {
+    html: propType.string.source({ type: 'html' }),
+  },
+  setup({ props, refs }) {
+    return [bind(refs.self, { html: computed(() => props.html) })];
+  },
+});
+
+export const Text: Story = () => ({
+  appComponents: [
+    lazy('cf-a2-icon', () => import(/* webpackExports: "lazy" */ '../../atom/cf-a2-icon/CfA2Icon')),
+    TextTest,
+  ],
+  component: defineComponent({
+    name: 'global-refresh',
+    setup({}) {
+      console.log('foo');
+      return [];
+    },
+  }),
+  template: () => html` <div data-component="global-refresh">
+    <div data-component="child">
+      ${cfA1Heading({ title: 'The quick brown fox jumped over the lazy dog', type: 'h1' })}
+      ${cfA2IconTemplate({ name: 'loader' })}
+      ${Array.from(
+        { length: 2000 },
+        (_, i) => html`<span data-component="text-test">this is line ${i} </span>`,
+      )}
+    </div>
+  </div>`,
+});

--- a/src/lib/Component.ts
+++ b/src/lib/Component.ts
@@ -76,6 +76,7 @@ export function createComponentInstance(
     children: [],
     refChildren: [],
     removeBindingsList: [],
+    disposers: [],
     mount() {
       // console.log('[mount]', options.name);
       this[LifecycleHooks.Mounted]?.forEach((hook) => hook());
@@ -86,6 +87,7 @@ export function createComponentInstance(
     unmount() {
       // console.log('[unmount]', options.name);
       this.removeBindingsList?.forEach((binding) => binding?.());
+      this.disposers?.forEach((dispose) => dispose());
       this[LifecycleHooks.Unmounted]?.forEach((hook) => hook());
 
       // unregister itself from its parent
@@ -164,7 +166,7 @@ export const defineComponent = <
       processNonRefChildComponents(instance);
 
       // listen for DOM removal and child component DOM updates
-      createObservers(instance);
+      instance.disposers.push(createObservers(instance));
 
       // only initialize itself when it's a "root" component
       // otherwise it's initialized by its parent
@@ -217,6 +219,26 @@ export const defineComponent = <
   );
 };
 
+let documentObserver: MutationObserver;
+const callbacks = new Set<() => void>();
+function onNodeRemoval(callback: () => void): () => void {
+  // observer is only added once on the document, and will trigger the callback for
+  // each mounted component, which will do its own checks
+  if (!documentObserver) {
+    documentObserver = new MutationObserver(() => {
+      for (const callback of callbacks) {
+        callback();
+      }
+    });
+    documentObserver.observe(document, { attributes: false, childList: true, subtree: true });
+  }
+  callbacks.add(callback);
+
+  return () => {
+    callbacks.delete(callback);
+  };
+}
+
 /**
  * Create MutationObservers for:
  * - the document to detect the deletion of this component
@@ -234,15 +256,16 @@ function createObservers(instance: InternalComponentInstance) {
   });
   elementObserver.observe(instance.element, { attributes: false, childList: true, subtree: true });
 
-  // each component will detect its own DOM removal and unmount itself
-  const documentObserver = new MutationObserver((mutations) => {
-    const removedNodes = mutations.flatMap((mutation) => Array.from(mutation.removedNodes));
-    if (removedNodes.some((node) => node === instance.element || node.contains(instance.element))) {
+  const disposeNodeRemovalCallback = onNodeRemoval(() => {
+    if (!instance.element.isConnected) {
       instance.unmount();
     }
   });
-  // TODO: only add this once
-  documentObserver.observe(document, { attributes: false, childList: true, subtree: true });
+
+  return () => {
+    elementObserver.disconnect();
+    disposeNodeRemovalCallback();
+  };
 }
 
 /**

--- a/src/lib/Component.types.ts
+++ b/src/lib/Component.types.ts
@@ -42,6 +42,7 @@ export type InternalComponentInstance = InternalNodeInstance & {
   bindings: Array<Binding>;
   refChildren: Array<InternalNodeInstance>;
   removeBindingsList?: Array<(() => void) | undefined>;
+  disposers: Array<() => void>;
   options: DefineComponentOptions<
     Record<string, PropTypeDefinition>,
     Record<string, ComponentRefItem>,

--- a/src/lib/bindings/dom/submitBinding.ts
+++ b/src/lib/bindings/dom/submitBinding.ts
@@ -2,7 +2,7 @@ export function submitBinding(
   target: HTMLFormElement,
   fn: (event: HTMLElementEventMap['submit']) => void | boolean,
 ) {
-  const submitHandler = (event: SubmitEvent) => {
+  const submitHandler = (event: Event) => {
     const returnValue = fn(event);
     // by default, prevent default form execution, unless explicitly returned by the handler
     if (returnValue !== true) {

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -2,7 +2,9 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "module": "ESNext",
+    "target": "ES6",
     "outDir": "./dist/esm",
-    "declarationDir": "./dist/esm"
+    "declarationDir": "./dist/esm",
+    "downlevelIteration": false
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,7 +6,7 @@
     "allowJs": false,
     "outDir": "tmp",
     "declaration": true,
-    "declarationDir": "./decl"
+    "declarationDir": "./decl",
   },
   "include": [
     "./src/**/*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+     "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */


### PR DESCRIPTION
There was a massive performance bottleneck caused by every component
creating their own global MutationObserver, which all got triggered
by every innerHTML update – exponential growth.

This update only creates a single global MutationObserver.

Additionally, the check to see if a components element is removed has
been massively simplified. Previously it would check to see if any of
the removed nodes where the component or one of its parents. Which
requires knowledge about all the removed nodes.

Now we just check if the Node.isConnected is false, which doesn't need
any of that information, and is way faster.

Additionally, we now properly cleanup the MutationObservers when the
component is unmounted, making sure no memory leaks occur here.