### PR TITLE
Proxy watch/watchEffect to allow auto-cleanup on component unmount

### DIFF
--- a/examples/src/components/core/watch/Watch.stories.ts
+++ b/examples/src/components/core/watch/Watch.stories.ts
@@ -1,0 +1,99 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Story } from '@muban/storybook/dist/client/preview/types-6-0';
+import { html } from '@muban/template';
+import {
+  bind,
+  bindTemplate,
+  defineComponent,
+  refComponent,
+  onUnmounted,
+  watchEffect,
+  watch,
+  ref,
+} from '../../../../../src';
+import { useToggle } from '../../../hooks/useToggle';
+
+export default {
+  title: 'core/watch/watch',
+};
+
+const Test = defineComponent({
+  name: 'test',
+  setup() {
+    const num = ref(0);
+    watchEffect(() => {
+      console.log('watchEffect', num.value);
+    });
+    watch(
+      () => num.value,
+      (value) => {
+        console.log('watch', value);
+      },
+    );
+    watch(
+      () => num.value,
+      (value) => {
+        console.log('watchImmediate', value);
+      },
+      { immediate: true },
+    );
+    watch(
+      () => [num.value, num.value],
+      (value) => {
+        console.log('watchMultiple', value);
+      },
+    );
+
+    setInterval(() => {
+      console.log('--');
+      ++num.value;
+    }, 1000);
+
+    console.log('test mounted');
+    onUnmounted(() => {
+      console.log('test unmounted');
+    });
+
+    return [];
+  },
+});
+
+export const Default: Story = () => ({
+  component: defineComponent({
+    name: 'story',
+    // components: [Test],
+    refs: {
+      btnMount: 'btnMount',
+      btnUnmount: 'btnUnmount',
+      container: 'container',
+      test: refComponent(Test, { isRequired: false }),
+    },
+    setup({ refs }) {
+      const [isMounted, toggleMounted] = useToggle(true);
+      return [
+        bind(refs.btnMount, {
+          click() {
+            toggleMounted(true);
+          },
+        }),
+        bind(refs.btnUnmount, {
+          click() {
+            toggleMounted(false);
+          },
+        }),
+        bindTemplate(refs.container, () => {
+          return isMounted.value ? html`<div data-component="test">Alive</div>` : '';
+        }),
+      ];
+    },
+  }),
+  template: () => html` <div data-component="story">
+    <p style="max-width: 350px">
+      Watch the console.log. After unmounting the component, the logging should stop. Even thought
+      the interval keeps updating the ref, the watchEffect is not being executed anymore.
+    </p>
+    <button data-ref="btnMount">mount</button>
+    <button data-ref="btnUnmount">unmount</button>
+    <div data-ref="container"></div>
+  </div>`,
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,14 +11,17 @@ export { propType } from './lib/props/propDefinitions';
 export { refElement, refCollection, refComponent, refComponents } from './lib/refs/refDefinitions';
 export { provide, inject, createContext } from './lib/api/apiInject';
 export { onMounted, onUnmounted } from './lib/api/apiLifecycle';
+export { watch, watchEffect } from './lib/api/apiWatch';
 export { bind, bindMap, bindTemplate } from './lib/bindings/bindingDefinitions';
 
 // re-export types of those libs, so they don't have to be installed separately
 export * from '@vue/reactivity';
-export {
-  watch,
-  watchEffect, // WatchCallback, // WatchEffect, // WatchOptions, // WatchSource, // WatchStopHandle,
-} from '@vue/runtime-core';
+
+// TODO: should we export types from runtime/core?
+// export {
+//   watch,
+//   watchEffect, // WatchCallback, // WatchEffect, // WatchOptions, // WatchSource, // WatchStopHandle,
+// } from '@vue/runtime-core';
 
 // TODO: devtools
 initDev();

--- a/src/lib/api/apiWatch.ts
+++ b/src/lib/api/apiWatch.ts
@@ -1,0 +1,79 @@
+/* eslint-disable @typescript-eslint/ban-types */
+import {
+  watch as vueWatch,
+  watchEffect as vueWatchEffect,
+  WatchCallback,
+  WatchEffect,
+  WatchOptions,
+  WatchOptionsBase,
+  WatchSource,
+  WatchStopHandle,
+} from '@vue/runtime-core';
+import { getCurrentComponentInstance } from '../Component';
+
+declare type MapSources<T, Immediate> = {
+  [K in keyof T]: T[K] extends WatchSource<infer V>
+    ? Immediate extends true
+      ? V | undefined
+      : V
+    : T[K] extends object
+    ? Immediate extends true
+      ? T[K] | undefined
+      : T[K]
+    : never;
+};
+declare type MultiWatchSources = Array<WatchSource<unknown> | object>;
+
+export function watch<T extends MultiWatchSources, Immediate extends Readonly<boolean> = false>(
+  sources: [...T],
+  cb: WatchCallback<MapSources<T, false>, MapSources<T, Immediate>>,
+  options?: WatchOptions<Immediate>,
+): WatchStopHandle;
+export function watch<
+  T extends Readonly<MultiWatchSources>,
+  Immediate extends Readonly<boolean> = false
+>(
+  source: T,
+  cb: WatchCallback<MapSources<T, false>, MapSources<T, Immediate>>,
+  options?: WatchOptions<Immediate>,
+): WatchStopHandle;
+export function watch<T, Immediate extends Readonly<boolean> = false>(
+  source: WatchSource<T>,
+  cb: WatchCallback<T, Immediate extends true ? T | undefined : T>,
+  options?: WatchOptions<Immediate>,
+): WatchStopHandle;
+export function watch<T extends object, Immediate extends Readonly<boolean> = false>(
+  source: T,
+  cb: WatchCallback<T, Immediate extends true ? T | undefined : T>,
+  options?: WatchOptions<Immediate>,
+): WatchStopHandle;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function watch(sources: any, cb: any, options: any): WatchStopHandle {
+  const instance = getCurrentComponentInstance();
+  // don't even create the effect if this component is not mounted
+  if (instance && instance.isUnmounted) {
+    return () => undefined;
+  }
+
+  const stopHandle = vueWatch(sources, cb, options);
+
+  // register stopHandle so it gets executed when the component unmounts
+  instance?.disposers.push(stopHandle);
+
+  return stopHandle;
+}
+
+export function watchEffect(effect: WatchEffect, options?: WatchOptionsBase): WatchStopHandle {
+  const instance = getCurrentComponentInstance();
+  // don't even create the effect if this component is not mounted
+  if (instance && instance.isUnmounted) {
+    return () => undefined;
+  }
+
+  const stopHandle = vueWatchEffect(effect, options);
+
+  // register stopHandle so it gets executed when the component unmounts
+  instance?.disposers.push(stopHandle);
+
+  return stopHandle;
+}

--- a/src/lib/refs/refDefinitions.ts
+++ b/src/lib/refs/refDefinitions.ts
@@ -296,6 +296,9 @@ export function refComponent<T extends ComponentFactory<any>>(
 
             if (!refInstance) {
               // create new component instance
+              // TODO: This component only gets "set up" when HTML is updated through `bindTemplate`.
+              //  If not, this is just an empty component that doesn't do anything.
+              //  Would be nice if we could improve this
               refInstance = newComponentFactory(element, { parent: instance }) as ReturnType<T>;
             }
             instance.children.push(refInstance);


### PR DESCRIPTION
`watch` and `watchEffect` exist in runtime-core instead of reactivity
packages because they are tied to the Vue components, and their
lifecycles. Which has some advantages, that Muban didn't have.

With this update, we proxy those two functions to allow for auto-cleanup
when the Muban component unmounts. It will also ignore usages when
invoked in an unmounted component.

For library consumers this should work out of the box, as long as they
use the muban exports (and not the vue exports directly).

Fixes #46 