### PR TITLE
Make SVGElement fix backwards compatible

### DIFF
--- a/src/lib/bindings/bindingDefinitions.ts
+++ b/src/lib/bindings/bindingDefinitions.ts
@@ -94,10 +94,7 @@ export function bindMap(
     // as soon as the underlying ref array updates when the items in the DOM
     // are updated
     const disposeWatch = watch(
-      () =>
-        (target as any).getRefs() as Array<
-          ElementRef<RefElementType, BindProps> | ComponentRef<ComponentFactory<any>>
-        >,
+      () => (target as any).getRefs() as Array<ElementRef | ComponentRef<ComponentFactory<any>>>,
       (refs, oldValue, onInvalidate) => {
         const bindings = refs.map((ref, index) => bind(ref, getProps(ref, index)));
 

--- a/src/lib/refs/refDefinitions.types.ts
+++ b/src/lib/refs/refDefinitions.types.ts
@@ -19,14 +19,14 @@ export type RefElementType = HTMLElement | SVGElement;
  * This is the raw "definition" for refs, represented as a simple object.
  * Any helper functions must return this object
  */
-export type ComponentRefItemElement<T extends RefElementType> = {
+export type ComponentRefItemElement<T extends RefElementType = HTMLElement> = {
   type: 'element';
   ref: string;
   queryRef: (parent: HTMLElement) => T | null;
   createRef: (instance: InternalComponentInstance) => ElementRef<T, BindProps>;
   isRequired?: boolean;
 };
-export type ComponentRefItemCollection<T extends RefElementType> = {
+export type ComponentRefItemCollection<T extends RefElementType = HTMLElement> = {
   type: 'collection';
   ref: string;
   queryRef: (parent: HTMLElement) => Array<T>;
@@ -70,14 +70,17 @@ export type ComponentRefItem =
  * - applying bindings
  * - get access to the elements/components related to the ref
  */
-export type ElementRef<T extends RefElementType, P extends BindProps> = {
+export type ElementRef<T extends RefElementType = HTMLElement, P extends BindProps = BindProps> = {
   type: 'element';
   getBindingDefinition: (props: P) => ElementBinding<T, P>;
   element: T | undefined;
   refreshRefs: () => void;
 };
 
-export type CollectionRef<T extends RefElementType, P extends BindProps> = {
+export type CollectionRef<
+  T extends RefElementType = HTMLElement,
+  P extends BindProps = BindProps
+> = {
   type: 'collection';
   getBindingDefinition: (props: BindProps) => CollectionBinding<T, P>;
   getElements: () => Array<T>;
@@ -105,8 +108,8 @@ export type ComponentsRef<T extends ComponentFactory<any>> = {
 };
 
 export type AnyRef =
-  | ElementRef<RefElementType, BindProps>
-  | CollectionRef<RefElementType, BindProps>
+  | ElementRef
+  | CollectionRef
   | ComponentRef<ComponentFactory<any>>
   | ComponentsRef<ComponentFactory<any>>;
 
@@ -137,7 +140,7 @@ export type TypedRef<T extends ComponentRefItem> = T extends {
   createRef: (instance: InternalComponentInstance) => infer R;
 }
   ? Exclude<R, undefined>
-  : ElementRef<RefElementType, BindProps>;
+  : ElementRef;
 
 /**
  * Extract typings out of the refDefinition input,
@@ -147,4 +150,4 @@ export type TypedRef<T extends ComponentRefItem> = T extends {
  */
 export type TypedRefs<T extends Record<string, ComponentRefItem>> = {
   [P in keyof T]: TypedRef<T[P]>;
-} & { self: ElementRef<HTMLElement, BindProps> };
+} & { self: ElementRef };


### PR DESCRIPTION
Previously we added`RefElementType` to allow both `HTMLElement` and
`SVGElement` for refs. However, this was also the default for all refs,
breaking existing code from projects and external libraries that expects
only HTML elements for refs.

This update still allows both types, but makes sure HTMLElement is the
default type when nothing is specified in the generic;

```ts
defaultRef: 'default',                  // default HTMLElement
defaultRef2: refElement('default'),     // default HTMLElement
htmlRef: refElement<HTMLDivElement>('html'),
svgRef: refElement<SVGElement>('svg'),
```

By providing this as defaults, we can also remove the passed generics in
some cases.