### PR TITLE
Fix `RefOrValue` when passing optional functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-alpha.32] - 2022-02-28
+
+### Fixed
+
+- Fixed bug from `alpha.31` where component props would be typed as `Ref` in bindings.
+
 ## [1.0.0-alpha.31] - 2022-02-28
 
 ### Breaking

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-alpha.32] - 2022-02-28
+
+### Fixed
+
+- Fixed bug from `alpha.31` where component props would be typed as `Ref` in bindings.
+
 ## [1.0.0-alpha.31] - 2022-02-28
 
 ### Breaking

--- a/src/lib/props/propDefinitions.types.test.ts
+++ b/src/lib/props/propDefinitions.types.test.ts
@@ -57,6 +57,8 @@ function createTest<P extends Record<string, PropTypeDefinition> = any>(options:
 const x = createTest({
   props: {
     foo: propType.string,
+    onChange: propType.func.shape<(event: MouseEvent) => void>(),
+    onClick: propType.func.optional.shape<(event: MouseEvent) => void>(),
   },
 });
 const y = createTest({});

--- a/src/lib/refs/refDefinitions.types.ts
+++ b/src/lib/refs/refDefinitions.types.ts
@@ -115,7 +115,8 @@ export type AnyRef<T extends RefElementType> =
 
 // Turn the keys of an object into the types, or a Ref around that type
 export type RefOrValue<T extends Record<string, any>> = {
-  [P in keyof T]: T[P] extends Function ? T[P] | Ref<T[P]> : Ref<T[P]>;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  [P in keyof T]: Exclude<T[P], undefined> extends Function ? T[P] | Ref<T[P]> : Ref<T[P]>;
 };
 
 export type ComponentParams<T> = ComponentSetPropsParam<T> &


### PR DESCRIPTION
The `extends Function` condition failed when `T[P]` could be undefined
(optional), causing all function props to be types as only `Refs`.

Using the `Exclude<T[P], undefined>` we can ignore `undefined`
functions, and restore the expected behaviour.