### PR TITLE
Also export declarations in `dist/esm` folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-alpha.33] - 2022-04-14
+
+### Fixed
+
+- Fixed importing of non-exported files by also exporting types in `dist/esm` folder.
+
 ## [1.0.0-alpha.32] - 2022-02-28
 
 ### Fixed

--- a/docs/changelog/README.md
+++ b/docs/changelog/README.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0-alpha.33] - 2022-04-14
+
+### Fixed
+
+- Fixed importing of non-exported files by also exporting types in `dist/esm` folder.
+
 ## [1.0.0-alpha.32] - 2022-02-28
 
 ### Fixed
@@ -99,13 +105,13 @@ the new behaviour. Previously you would have to be explicit about when the `bind
 render immediately or not, while the new implementation does this based on the existence of any HTML
 inside the container. `forceImmediateRender` can override this behaviour.
 
-> **Note:** Previously, `watch` was used to watch for explicit changes to the passed computed. 
-> This would have been "shallow" by default, and other reactive data used in the template 
+> **Note:** Previously, `watch` was used to watch for explicit changes to the passed computed.
+> This would have been "shallow" by default, and other reactive data used in the template
 > function would not trigger a rerender.
-> 
-> The new implementation uses `watchEffect`, which is triggered by any reactive updates in the 
+>
+> The new implementation uses `watchEffect`, which is triggered by any reactive updates in the
 > `onUpdate` function, but also watches refs that have nested objects deeply by default.
-> 
+>
 > To only update changes to the `ref.value`, a `shallowRef` can be used instead.
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@muban/muban",
-  "version": "1.0.0-alpha.32",
+  "version": "1.0.0-alpha.33",
   "description": "Writing components for server-rendered HTML",
   "keywords": [
     "muban",
@@ -32,7 +32,6 @@
     "build:ts-esm": "tsc -p ./tsconfig.build.esm.json",
     "clean": "npm-run-all clean:*",
     "clean:test": "shx rm -rf coverage .nyc_output",
-    "clean:build": "shx rm -rf tmp",
     "clean:npm": "shx rm -rf dist types",
     "lint": "eslint --ext .js,.jsx,.ts,.tsx src",
     "test": "jest ./src/",

--- a/tsconfig.build.cjs.json
+++ b/tsconfig.build.cjs.json
@@ -4,7 +4,9 @@
     "target": "es5",
     "module": "commonjs",
     "allowJs": false,
-    "outDir": "./dist/cjs"
+    "outDir": "./dist/cjs",
+    "declaration": true,
+    "declarationDir": "./types"
   },
   "include": [
     "./src/**/*"

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -6,6 +6,6 @@
     "outDir": "./dist/esm",
     "downlevelIteration": false,
     "declaration": true,
-    "declarationDir": "./types"
+    "declarationDir": "./dist/esm"
   }
 }


### PR DESCRIPTION
Previously it was not possible to import anything from
`@muban/muban/dist/esm/...` directly, since it wouldn't match the path
for types; `@muban/muban/types/...`.

With this change, the declarations are now also exported in the
`dist/esm` folder, so that those files can be imported without any TS
error.

The existing `types` folder is still there for convenience in case
non-exported types should be imported.