### PR TITLE
Namespace element bindings on component refs

### DIFF
--- a/src/lib/bindings/applyBindings.ts
+++ b/src/lib/bindings/applyBindings.ts
@@ -117,13 +117,17 @@ export const applyBindings = (
       if (binding.type === 'component') {
         typedObjectEntries(binding.props).forEach(([propName, bindingValue]) => {
           watchEffect(() => {
-            if (['css', 'style', 'attr', 'event'].includes(propName)) {
-              const element = unref(binding.ref)?.element;
-              if (element) {
-                bindingsList[propName as 'css' | 'style' | 'attr' | 'event']?.(
-                  element,
-                  bindingValue as any,
-                );
+            if (propName === '$element') {
+              for (const [elementBindingKey, elementBindingValue] of Object.entries(bindingValue)) {
+                if (['css', 'style', 'attr', 'event'].includes(elementBindingKey)) {
+                  const element = unref(binding.ref)?.element;
+                  if (element) {
+                    bindingsList[elementBindingKey as 'css' | 'style' | 'attr' | 'event']?.(
+                      element,
+                      elementBindingValue as any,
+                    );
+                  }
+                }
               }
             } else {
               unref(binding.ref)?.setProps({
@@ -139,11 +143,17 @@ export const applyBindings = (
             // eslint-disable-next-line no-shadow
             reff?.forEach((ref) => {
               watchEffect(() => {
-                if (['css', 'style', 'attr'].includes(propName)) {
-                  bindingsList[propName as 'css' | 'style' | 'attr']?.(
-                    unref(ref).element,
-                    bindingValue as any,
-                  );
+                if (propName === '$element') {
+                  for (const [elementBindingKey, elementBindingValue] of Object.entries(
+                    bindingValue,
+                  )) {
+                    if (['css', 'style', 'attr'].includes(elementBindingKey)) {
+                      bindingsList[elementBindingKey as 'css' | 'style' | 'attr']?.(
+                        unref(ref).element,
+                        elementBindingValue as any,
+                      );
+                    }
+                  }
                 } else {
                   ref?.setProps({
                     [propName]: unref(bindingValue),

--- a/src/lib/bindings/bindings.test.ts
+++ b/src/lib/bindings/bindings.test.ts
@@ -1,0 +1,45 @@
+import dedent from 'ts-dedent';
+import { computed, bind } from '../..';
+import { defineComponent } from '../Component';
+import { propType } from '../props/propDefinitions';
+import { refComponent } from '../refs/refDefinitions';
+
+it('Should namespace the child component bindings', async () => {
+  const SomeChildComponent = defineComponent({
+    name: 'some-child-component',
+    props: {
+      style: propType.string,
+    },
+  });
+
+  const myElement = document.createElement('div');
+  myElement.setAttribute('data-component', 'some-parent-component');
+  myElement.innerHTML = dedent`
+    <div data-component="some-child-component" data-ref="child" data-style="primary"></div>
+  `;
+  document.body.appendChild(myElement);
+
+  const SomeParentComponent = defineComponent({
+    name: 'some-parent-component',
+    refs: {
+      child: refComponent(SomeChildComponent, { ref: 'child' }),
+    },
+    setup({ refs }) {
+      return [
+        bind(refs.child, {
+          style: computed(() => 'secondary'),
+          $element: {
+            css: computed(() => ({
+              'is-active': true,
+            })),
+          },
+        }),
+      ];
+    },
+  })(myElement);
+
+  expect(
+    SomeParentComponent.element.querySelector('[data-ref=child]')?.classList.contains('is-active'),
+  ).toBe(true);
+  expect(SomeParentComponent.__instance.children[0].props.style).toBe('secondary');
+});

--- a/src/lib/refs/refDefinitions.types.ts
+++ b/src/lib/refs/refDefinitions.types.ts
@@ -119,8 +119,11 @@ export type RefOrValue<T extends Record<string, any>> = {
   [P in keyof T]: Exclude<T[P], undefined> extends Function ? T[P] | Ref<T[P]> : Ref<T[P]>;
 };
 
-export type ComponentParams<T> = ComponentSetPropsParam<T> &
-  Pick<BindProps, 'css' | 'style' | 'attr' | 'event'>;
+type ChildComponentParams = {
+  $element?: Pick<BindProps, 'css' | 'style' | 'attr' | 'event'>;
+};
+
+export type ComponentParams<T> = ComponentSetPropsParam<T> & ChildComponentParams;
 
 /**
  * Extracts the props from a component if it is one


### PR DESCRIPTION
Update the way bindings are applied to component refs

The new "$element" key was added to the ComponentParams types