### PR TITLE
Update Component to avoid double mounting of ref components

### DIFF
--- a/src/lib/refs/refDefinitions.test.ts
+++ b/src/lib/refs/refDefinitions.test.ts
@@ -133,6 +133,25 @@ describe('refElement', () => {
       });
     });
   });
+  describe('when nesting refs', () => {
+    it('should throw an error', () => {
+      const parent = createComponentTemplateElement(`<div data-ref="test"></div>`);
+      const refItem = refElement('test');
+      const instance = createComponentInstance({}, parent, { name: 'parent', setup: () => [] });
+      refItem.createRef(instance);
+
+      const createSecondRef = () => {
+        const secondRefItem = refElement('test');
+        const secondInstance = createComponentInstance({}, parent, {
+          name: 'parent',
+          setup: () => [],
+        });
+        secondRefItem.createRef(secondInstance);
+      };
+
+      expect(createSecondRef).toThrow();
+    });
+  });
 });
 
 describe('refCollection', () => {

--- a/src/lib/refs/refDefinitions.test.ts
+++ b/src/lib/refs/refDefinitions.test.ts
@@ -412,6 +412,24 @@ describe('refComponent', () => {
     //     });
     //   });
   });
+  describe('When nesting refs', () => {
+    it('should throw an error', () => {
+      const parent = createComponentTemplateElement(`<div data-component="test"></div>`);
+      const refItem = refComponent(TestComponent);
+      const instance = createComponentInstance({}, parent, { name: 'parent', setup: () => [] });
+      refItem.createRef(instance);
+
+      const createSecondRef = () => {
+        const secondRefItem = refComponent(TestComponent);
+        const secondInstance = createComponentInstance({}, parent, {
+          name: 'parent',
+          setup: () => [],
+        });
+        secondRefItem.createRef(secondInstance);
+      };
+      expect(createSecondRef).toThrow();
+    });
+  });
 });
 
 describe('refComponents', () => {

--- a/src/lib/refs/refDefinitions.test.ts
+++ b/src/lib/refs/refDefinitions.test.ts
@@ -133,7 +133,7 @@ describe('refElement', () => {
       });
     });
   });
-  describe('when nesting refs', () => {
+  describe('when having multiple owners of a ref', () => {
     it('should throw an error', () => {
       const parent = createComponentTemplateElement(`<div data-ref="test"></div>`);
       const refItem = refElement('test');
@@ -248,6 +248,25 @@ describe('refCollection', () => {
       it('should return the same element when not changed', () => {
         // TODO after other PR is merged that updates this API interface
       });
+    });
+  });
+  describe('when having multiple owners of a ref', () => {
+    it('should throw an error', () => {
+      const parent = createComponentTemplateElement(`<div data-ref="test"></div>`);
+      const refItems = refCollection('test');
+      const instance = createComponentInstance({}, parent, { name: 'parent', setup: () => [] });
+      refItems.createRef(instance);
+
+      const createSecondRef = () => {
+        const secondRefItems = refCollection('test');
+        const secondInstance = createComponentInstance({}, parent, {
+          name: 'parent',
+          setup: () => [],
+        });
+        secondRefItems.createRef(secondInstance);
+      };
+
+      expect(createSecondRef).toThrow();
     });
   });
 });
@@ -431,7 +450,7 @@ describe('refComponent', () => {
     //     });
     //   });
   });
-  describe('When nesting refs', () => {
+  describe('when having multiple owners of a ref', () => {
     it('should throw an error', () => {
       const parent = createComponentTemplateElement(`<div data-component="test"></div>`);
       const refItem = refComponent(TestComponent);

--- a/src/lib/refs/refDefinitions.test.ts
+++ b/src/lib/refs/refDefinitions.test.ts
@@ -450,7 +450,7 @@ describe('refComponent', () => {
     //     });
     //   });
   });
-  describe('when having multiple owners of a ref', () => {
+  describe('when having multiple owners of a refComponent', () => {
     it('should throw an error', () => {
       const parent = createComponentTemplateElement(`<div data-component="test"></div>`);
       const refItem = refComponent(TestComponent);
@@ -607,6 +607,29 @@ describe('refComponents', () => {
       it('should return the same element when not changed', () => {
         // TODO after other PR is merged that updates this API interface
       });
+    });
+  });
+  describe('when having multiple owners of a refComponent collection', () => {
+    it('should throw an error', () => {
+      const parent = createComponentTemplateElement(`
+        <div>
+          <div data-component="test"></div>
+          <div data-component="test"></div>
+        </div>
+      `);
+      const refItems = refComponents(TestComponent);
+      const instance = createComponentInstance({}, parent, { name: 'parent', setup: () => [] });
+      refItems.createRef(instance);
+
+      const createSecondRefCollection = () => {
+        const secondRefItems = refComponents(TestComponent);
+        const secondInstance = createComponentInstance({}, parent, {
+          name: 'parent',
+          setup: () => [],
+        });
+        secondRefItems.createRef(secondInstance);
+      };
+      expect(createSecondRefCollection).toThrow();
     });
   });
 });

--- a/src/lib/refs/refDefinitions.ts
+++ b/src/lib/refs/refDefinitions.ts
@@ -85,7 +85,7 @@ function getExistingGlobalRefComponent<T extends ComponentApi>(
       refInstance = existingComponent as T;
     } else {
       throw new Error(
-        `This refComponent does already exist as part of another parent
+        `This refComponent ${element} does already exist as part of another parent
         ${existingComponent.__instance.parent}`,
       );
     }

--- a/src/lib/refs/refDefinitions.ts
+++ b/src/lib/refs/refDefinitions.ts
@@ -80,12 +80,9 @@ function getExistingGlobalRefComponent<T extends ComponentApi>(
       existingComponent.__instance.parent = instance;
       refInstance = existingComponent as T;
     } else {
-      // TODO: not sure what to do here, for now we just let the component be
-      //  re-created, which shows additional warnings
-      // eslint-disable-next-line no-console
-      console.error(
-        'This refComponent does already exist as part of another parent',
-        existingComponent.__instance.parent,
+      throw new Error(
+        `This refComponent does already exist as part of another parent
+        ${existingComponent.__instance.parent}`,
       );
     }
   }

--- a/src/lib/refs/refDefinitions.ts
+++ b/src/lib/refs/refDefinitions.ts
@@ -99,7 +99,7 @@ function checkForExistingGlobalRefElement(element: RefElementType) {
   const existingComponent = getComponentForElementRef(element);
   if (existingComponent) {
     throw new Error(
-      `This refElement does already exist as part of another parent
+      `refElement ${element} does already exist as part of another parent
       ${existingComponent}`,
     );
   }

--- a/src/lib/refs/refDefinitions.ts
+++ b/src/lib/refs/refDefinitions.ts
@@ -85,8 +85,8 @@ function getExistingGlobalRefComponent<T extends ComponentApi>(
       refInstance = existingComponent as T;
     } else {
       throw new Error(
-        `This refComponent ${element} does already exist as part of another parent
-        ${existingComponent.__instance.parent}`,
+        `This refComponent ${element.outerHTML} does already exist as part of another parent:
+        "${existingComponent.__instance.parent?.name}"`,
       );
     }
   }
@@ -99,8 +99,8 @@ function checkForExistingGlobalRefElement(element: RefElementType) {
   const existingComponent = getComponentForElementRef(element);
   if (existingComponent) {
     throw new Error(
-      `refElement ${element} does already exist as part of another parent
-      ${existingComponent}`,
+      `refElement ${element.outerHTML} does already exist as part of another parent:
+      "${existingComponent.name}"`,
     );
   }
 }

--- a/src/lib/refs/refDefinitions.ts
+++ b/src/lib/refs/refDefinitions.ts
@@ -95,7 +95,7 @@ function getExistingGlobalRefComponent<T extends ComponentApi>(
   return refInstance;
 }
 
-function getExistingGlobalRefElement(element: RefElementType) {
+function checkForExistingGlobalRefElement(element: RefElementType) {
   const existingComponent = getComponentForElementRef(element);
   if (existingComponent) {
     throw new Error(
@@ -158,8 +158,8 @@ If you want to select a custom target, pass a function like;
       };
       elementRef.value = getElement(true) ?? undefined;
 
-      if (elementRef.value && instance) {
-        getExistingGlobalRefElement(elementRef.value);
+      if (elementRef.value) {
+        checkForExistingGlobalRefElement(elementRef.value);
         registerComponentForElementRef(elementRef.value, instance);
       }
 
@@ -228,6 +228,11 @@ If you want to select a custom target, pass a function like;
         return elements.map((element) => ref(element) as Ref<T>);
       };
       elementsRef.value = getElements();
+
+      elementsRef.value.forEach((element) => {
+        checkForExistingGlobalRefElement(element.value);
+        registerComponentForElementRef(element.value, instance);
+      });
 
       return {
         type: 'collection',

--- a/src/lib/utils/global.ts
+++ b/src/lib/utils/global.ts
@@ -16,11 +16,13 @@ import { createJsonScriptPropertySource } from '../props/property-sources/create
 import { createReactivePropertySource } from '../props/property-sources/createReactivePropertySource';
 import { createCustomPropertySource } from '../props/property-sources/createCustomPropertySource';
 import { createFormPropertySource } from '../props/property-sources/createFormPropertySource';
+import type { RefElementType } from '../refs/refDefinitions.types';
 
 // TODO: Move to "App"?
 class MubanGlobal {
   public readonly components = new Map<string, ComponentFactory | LazyComponent>();
   public readonly instances = new Map<HTMLElement, ComponentApi>();
+  public readonly elementRefs = new Map<RefElementType, InternalComponentInstance>();
   public readonly loadingElements = new Set<HTMLElement>();
   public readonly propertySources: Array<PropertySource> = [
     createClassListPropertySource(),
@@ -179,4 +181,15 @@ export function setComponentElementLoadingState(element: HTMLElement, isLoading:
 
 function isComponentElementLoadingOrInitialized(element: HTMLElement): boolean {
   return globalInstance.instances.has(element) || globalInstance.loadingElements.has(element);
+}
+
+export function getComponentForElementRef(element: RefElementType) {
+  return globalInstance.elementRefs.get(element);
+}
+
+export function registerComponentForElementRef(
+  element: RefElementType,
+  component: InternalComponentInstance,
+) {
+  globalInstance.elementRefs.set(element, component);
 }


### PR DESCRIPTION
@ThaNarie this is my initial approach to prevent double mounting

I have three variables: `newInstance` is a fresh instance created with the given createOptions, and `instance` that can be a previously existing instance or a reference to `newInstance` and `isInstantiated` a boolean that's `true` if there's a previous instance created

Then I spread refs, props and reactivePros from `instance` when setting those values for `newInstance`, that way I'm using the `newInstance` as an extended previous instance

Then I'm passing `instance` to `setupComponent()` and a new argument `alreadyInstantiated` to conditionally trigger `mount()`

That way bindings are applied only In one instance, makes sense?
